### PR TITLE
add acs table pulls

### DIFF
--- a/pytidycensus/utils.py
+++ b/pytidycensus/utils.py
@@ -723,6 +723,8 @@ def add_margin_of_error(
 
     if output == "tidy":
         # For tidy format, we need to create a separate 'moe' column
+        # Ensure variable column is string type for str accessor
+        df["variable"] = df["variable"].astype(str)
         # First, separate estimate and MOE rows
         estimate_rows = df[~df["variable"].str.endswith("M")].copy()
         moe_rows = df[df["variable"].str.endswith("M")].copy()


### PR DESCRIPTION
fixes #8 
This pull request introduces improvements to the `pytidycensus` library, focusing on data type handling in the utility function and enhancing unit testing for ACS table retrieval. The main changes ensure more robust processing of variable columns and add comprehensive tests that compare Python output to the R tidycensus package for a key ACS table.

**Data handling improvements:**

* Ensured the `variable` column in dataframes is explicitly converted to string type in the `add_margin_of_error` function to avoid issues with string operations on non-string types.

**Testing enhancements:**

* Added a new unit test `test_get_acs_table_b01001_returns_expected_values` in `tests/test_acs.py` to verify that the output for table `B01001` matches expected values from the R tidycensus package, including checks for correct estimates, margin of error handling, and proper column values.