### PR TITLE
fixed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytidycensus"
-version = "0.1.6"
+version = "0.1.7"
 description = "Python interface to US Census Bureau APIs with pandas and GeoPandas support"
 readme = "README.md"
 license = {text = "MIT"}

--- a/pytidycensus/acs.py
+++ b/pytidycensus/acs.py
@@ -288,35 +288,99 @@ def get_acs(
                 if summary_moe not in all_variables:
                     all_variables.append(summary_moe)
 
+    # Handle large variable lists by chunking (Census API limit is 50 variables)
+    # Reserve space for geography variables by using 48 as chunk size
+    MAX_VARIABLES_PER_REQUEST = 48
+
     # Make API request
     try:
-        # Remove duplicate print that was moved up to validation section
-
-        data = api.get(
-            year=year,
-            dataset="acs",
-            variables=all_variables,
-            geography=geo_params,
-            survey=survey,
-            show_call=show_call,
-        )
-
         # convert to wide if requesting geometry
         if geometry:
             output = "wide"
 
-        # Filter variables to only those present in the data
-        if data:
-            available_vars = list(data[0].keys())
-            filtered_variables = [var for var in all_variables if var in available_vars]
+        if len(all_variables) <= MAX_VARIABLES_PER_REQUEST:
+            # Single API request for small variable lists
+            data = api.get(
+                year=year,
+                dataset="acs",
+                variables=all_variables,
+                geography=geo_params,
+                survey=survey,
+                show_call=show_call,
+            )
+
+            # Filter variables to only those present in the data
+            if data:
+                available_vars = list(data[0].keys())
+                filtered_variables = [var for var in all_variables if var in available_vars]
+            else:
+                filtered_variables = all_variables
+
+            # Separate data variables from identifier variables like NAME
+            data_variables = [var for var in filtered_variables if var != "NAME"]
+
+            # Process data (use only data variables, not NAME)
+            df = process_census_data(data, data_variables, output)
         else:
-            filtered_variables = all_variables
+            # Multiple API requests for large variable lists (like full tables)
+            print(
+                f"Large table request: {len(all_variables)} variables will be retrieved in chunks"
+            )
 
-        # Separate data variables from identifier variables like NAME
-        data_variables = [var for var in filtered_variables if var != "NAME"]
+            # Split variables into chunks
+            variable_chunks = [
+                all_variables[i : i + MAX_VARIABLES_PER_REQUEST]
+                for i in range(0, len(all_variables), MAX_VARIABLES_PER_REQUEST)
+            ]
 
-        # Process data (use only data variables, not NAME)
-        df = process_census_data(data, data_variables, output)
+            chunk_dfs = []
+            for i, chunk in enumerate(variable_chunks):
+                if show_call:
+                    print(
+                        f"Processing chunk {i+1}/{len(variable_chunks)} with {len(chunk)} variables"
+                    )
+
+                chunk_data = api.get(
+                    year=year,
+                    dataset="acs",
+                    variables=chunk,
+                    geography=geo_params,
+                    survey=survey,
+                    show_call=show_call,
+                )
+
+                # Separate data variables from identifier variables like NAME
+                chunk_data_vars = [var for var in chunk if var != "NAME"]
+                chunk_df = process_census_data(chunk_data, chunk_data_vars, output)
+                chunk_dfs.append(chunk_df)
+
+            # Combine all chunks
+            if output == "tidy":
+                # For tidy format, just concatenate all chunks
+                df = pd.concat(chunk_dfs, ignore_index=True)
+            else:
+                # For wide format, merge chunks on geography columns
+                df = chunk_dfs[0]
+                geo_cols = [
+                    col
+                    for col in df.columns
+                    if col in ["GEOID", "NAME", "state", "county", "tract"]
+                ]
+
+                for chunk_df in chunk_dfs[1:]:
+                    # Find common geography columns for joining
+                    join_cols = [col for col in geo_cols if col in chunk_df.columns]
+                    if join_cols:
+                        df = df.merge(chunk_df, on=join_cols, how="outer")
+                    else:
+                        # Fallback: try merging on GEOID if available
+                        if "GEOID" in df.columns and "GEOID" in chunk_df.columns:
+                            df = df.merge(chunk_df, on="GEOID", how="outer")
+                        else:
+                            print(
+                                "Warning: Unable to merge chunks - no common geography columns found"
+                            )
+                            df = pd.concat([df, chunk_df], ignore_index=True)
 
         # Add margin of error handling with MOE level adjustment
         df = add_margin_of_error(df, all_variables, moe_level=moe_level, output=output)


### PR DESCRIPTION
This pull request introduces chunking support for large variable lists in the `get_acs` function, ensuring compatibility with Census API limits and improving reliability for requests involving full tables. It also adds a comprehensive integration test for the B01001 table to verify chunking and data correctness. The version is incremented to 0.1.7 to reflect these enhancements.

**API request handling improvements:**

* Added logic to split large variable lists into chunks of 48 variables per request in `get_acs`, ensuring compliance with the Census API's 50-variable limit and reserving space for geography variables. 
* For chunked requests, results are concatenated (tidy format) or merged on geography columns (wide format) to produce a unified DataFrame.

**Testing and reliability:**

* Added a new integration test for the B01001 table in `tests/test_integration.py` to validate chunked API requests, check for expected variables and columns, and ensure data quality.

**Versioning:**

* Bumped the package version in `pyproject.toml` from 0.1.6 to 0.1.7 to reflect the new features.