### PR TITLE
fix decen block pull

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 *.egg-info/
 dist/
 build/
+_build/
 
 # Sphinx docs
 /docs/_build/

--- a/docs/pytidycensus_intro.md
+++ b/docs/pytidycensus_intro.md
@@ -406,3 +406,7 @@ The printed URL can be copy-pasted into a web browser where users can see the ra
 ## Conclusion
 
 This introduction to `pytidycensus` has covered the basics of retrieving and working with Census data in Python. The package provides a convenient interface to access data from the US Census Bureau's APIs, with built-in support for spatial data analysis. For more information and examples, please refer to the examples directory and the package documentation.
+
+### Credits
+
+Thannks to [Kyle Walker](https://www.tcu.edu/directory/profile/kyle-walker.php) for developing this amazing tutorial in R, which I ported to Python.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytidycensus"
-version = "0.1.7"
+version = "0.1.8"
 description = "Python interface to US Census Bureau APIs with pandas and GeoPandas support"
 readme = "README.md"
 license = {text = "MIT"}

--- a/pytidycensus/acs.py
+++ b/pytidycensus/acs.py
@@ -168,7 +168,7 @@ def get_acs(
 
     # Validate inputs
     year = validate_year(year, "acs")
-    geography = validate_geography(geography)
+    geography = validate_geography(geography, dataset="acs")
 
     # Survey validation (mirror R tidycensus)
     if survey == "acs5" and year < 2009:

--- a/pytidycensus/decennial.py
+++ b/pytidycensus/decennial.py
@@ -144,7 +144,7 @@ def get_decennial(
 
     # Validate inputs (mirror R tidycensus)
     year = validate_year(year, "dec")
-    geography = validate_geography(geography)
+    geography = validate_geography(geography, dataset="decennial")
 
     # 1990 data not available (mirror R tidycensus)
     if year == 1990:

--- a/tests/test_decennial_block_geography.py
+++ b/tests/test_decennial_block_geography.py
@@ -1,0 +1,89 @@
+"""Tests for block geography in Decennial Census."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from pytidycensus.decennial import get_decennial
+from pytidycensus.utils import build_geography_params, validate_geography
+
+
+class TestDecennialBlockGeography:
+    """Test that block geography works correctly in Decennial Census."""
+
+    def test_validate_geography_allows_block_for_decennial(self):
+        """Test that validate_geography allows block for decennial dataset."""
+        result = validate_geography("block", dataset="decennial")
+        assert result == "block"
+
+    def test_build_geography_params_handles_block_geography(self):
+        """Test that build_geography_params correctly handles block geography."""
+        # Test basic block geography
+        params = build_geography_params("block")
+        assert params["for"] == "block:*"
+        assert "in" not in params
+
+        # Test block geography with state
+        params = build_geography_params("block", state="OK")
+        assert params["for"] == "block:*"
+        assert params["in"] == "state:40"
+
+        # Test block geography with state and county
+        params = build_geography_params("block", state="OK", county="025")
+        assert params["for"] == "block:*"
+        assert params["in"] == "state:40 county:025"
+
+    @patch("pytidycensus.decennial.CensusAPI")
+    def test_get_decennial_accepts_block_geography(self, mock_api_class):
+        """Test that get_decennial accepts block geography without errors."""
+        mock_api = Mock()
+        mock_api.get.return_value = [
+            {"H1_001N": "4", "state": "40", "county": "025", "tract": "000100", "block": "1000"}
+        ]
+        mock_api_class.return_value = mock_api
+
+        with patch("pytidycensus.decennial.process_census_data") as mock_process:
+            import pandas as pd
+
+            mock_process.return_value = pd.DataFrame(
+                {
+                    "H1_001N": ["4"],
+                    "state": ["40"],
+                    "county": ["025"],
+                    "tract": ["000100"],
+                    "block": ["1000"],
+                    "GEOID": ["40025000100001000"],
+                }
+            )
+
+            # This should not raise any NotImplementedError
+            result = get_decennial(
+                geography="block",
+                variables="H1_001N",
+                state="OK",
+                county="025",
+                year=2020,
+                sumfile="pl",
+                api_key="test",
+            )
+
+        # Verify the API call was made correctly
+        mock_api.get.assert_called_once()
+        call_kwargs = mock_api.get.call_args[1]
+        assert call_kwargs["geography"]["for"] == "block:*"
+        assert call_kwargs["geography"]["in"] == "state:40 county:025"
+
+    def test_validate_geography_rejects_block_for_acs(self):
+        """Test that validate_geography rejects block for ACS dataset."""
+        with pytest.raises(NotImplementedError, match="not available in ACS data"):
+            validate_geography("block", dataset="acs")
+
+    def test_validate_geography_allows_block_for_estimates(self):
+        """Test behavior with estimates dataset (should reject since blocks not in estimates)."""
+        with pytest.raises(NotImplementedError, match="not available in estimates data"):
+            validate_geography("block", dataset="estimates")
+
+    def test_validate_geography_backwards_compatibility(self):
+        """Test that block works when no dataset is specified (backwards compatibility)."""
+        result = validate_geography("block")
+        assert result == "block"

--- a/tests/test_unimplemented_geographies.py
+++ b/tests/test_unimplemented_geographies.py
@@ -36,12 +36,22 @@ class TestUnimplementedGeographyErrors:
         with pytest.raises(NotImplementedError, match="recognized but not yet implemented"):
             validate_geography("urban area")
 
-    def test_validate_geography_raises_not_implemented_for_block(self):
-        """Test that block geography raises specific NotImplementedError."""
-        with pytest.raises(
-            NotImplementedError, match="Block-level geography is not available in ACS data"
-        ):
-            validate_geography("block")
+    def test_validate_geography_raises_not_implemented_for_block_in_acs(self):
+        """Test that block geography raises specific NotImplementedError for ACS."""
+        with pytest.raises(NotImplementedError, match="not available in ACS data"):
+            validate_geography("block", dataset="acs")
+
+    def test_validate_geography_allows_block_in_decennial(self):
+        """Test that block geography is allowed for Decennial Census."""
+        # Should not raise any error
+        result = validate_geography("block", dataset="decennial")
+        assert result == "block"
+
+    def test_validate_geography_allows_block_when_no_dataset_specified(self):
+        """Test that block geography is allowed when no dataset is specified."""
+        # Should not raise any error (backwards compatibility)
+        result = validate_geography("block")
+        assert result == "block"
 
     def test_validate_geography_raises_not_implemented_for_necta(self):
         """Test that NECTA raises NotImplementedError."""
@@ -71,6 +81,17 @@ class TestUnimplementedGeographyErrors:
                 api_key="test",
             )
 
+    def test_get_acs_raises_not_implemented_for_block_geography(self):
+        """Test that get_acs raises NotImplementedError for block geography."""
+        with pytest.raises(NotImplementedError, match="not available in ACS data"):
+            get_acs(
+                geography="block",
+                variables="B01001_001E",
+                state="06",
+                year=2020,
+                api_key="test",
+            )
+
     def test_validate_geography_raises_value_error_for_unknown_geography(self):
         """Test that completely unknown geography raises ValueError."""
         with pytest.raises(ValueError, match="not recognized"):
@@ -92,6 +113,9 @@ class TestUnimplementedGeographyErrors:
         )
         assert validate_geography("congressional district") == "congressional district"
         assert validate_geography("public use microdata area") == "public use microdata area"
+        # Block should work for decennial or when no dataset specified
+        assert validate_geography("block", dataset="decennial") == "block"
+        assert validate_geography("block") == "block"
 
     def test_legacy_aliases_work(self):
         """Test that legacy aliases work correctly."""


### PR DESCRIPTION
This pull request adds support for block-level geography in the Decennial Census, improves context-aware validation of geographies, and updates tests to reflect these changes. The most important changes are grouped below by theme.

**Block Geography Support for Decennial Census:**

* Updated `validate_geography` in `pytidycensus/utils.py` to allow `"block"` geography for the Decennial Census dataset, while raising a clear `NotImplementedError` if used with ACS or estimates datasets. Backwards compatibility is maintained for cases where the dataset is not specified.  
* Modified `build_geography_params` to correctly construct API parameters for block-level queries, including handling state and county arguments. 
* Updated `get_decennial` and `get_acs` to pass the dataset type to geography validation, ensuring correct behavior for block geography.  
**Testing Enhancements:**

* Added a new test file `tests/test_decennial_block_geography.py` with comprehensive tests for block geography in the Decennial Census, including validation, parameter building, and API integration.
* Expanded tests in `tests/test_unimplemented_geographies.py` to cover block geography handling for ACS, Decennial, and backwards compatibility, as well as ensuring correct errors are raised for unsupported cases.  

**Documentation and Versioning:**

* Updated the version in `pyproject.toml` to `0.1.8` to reflect the new feature.
* Added credits to the documentation in `docs/pytidycensus_intro.md` acknowledging the source tutorial.