### PR TITLE
resolve DC and verify state codes

### DIFF
--- a/tests/test_dc_integration.py
+++ b/tests/test_dc_integration.py
@@ -1,0 +1,135 @@
+"""Integration tests for DC state parameter handling."""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from pytidycensus import get_acs, get_decennial
+
+
+class TestDCIntegration:
+    """Test that DC works as a state parameter in main functions."""
+
+    @patch("pytidycensus.acs.CensusAPI")
+    def test_get_acs_with_dc_variations(self, mock_api_class):
+        """Test that get_acs accepts all DC variations."""
+        # Mock the API response
+        mock_api = MagicMock()
+        mock_api_class.return_value = mock_api
+        mock_api.get.return_value = [
+            {"B01003_001E": "705749", "state": "11", "NAME": "District of Columbia"}
+        ]
+
+        dc_variations = ["DC", "11", "District of Columbia"]
+
+        for dc_var in dc_variations:
+            # This should not raise any validation errors
+            try:
+                result = get_acs(
+                    geography="state",
+                    variables=["B01003_001E"],
+                    state=dc_var,
+                    year=2020,
+                    api_key="test_key",
+                )
+
+                # Verify the result is a DataFrame
+                assert isinstance(result, pd.DataFrame)
+
+                # Verify the API was called with the correct parameters
+                mock_api.get.assert_called()
+                call_args = mock_api.get.call_args
+
+                # Should have converted DC to FIPS 11
+                geography_param = call_args[1]["geography"]
+                assert "11" in str(geography_param), f"Failed for {dc_var}: {geography_param}"
+
+            except Exception as e:
+                pytest.fail(f"get_acs failed for DC variation '{dc_var}': {e}")
+
+    @patch("pytidycensus.decennial.CensusAPI")
+    def test_get_decennial_with_dc_variations(self, mock_api_class):
+        """Test that get_decennial accepts all DC variations."""
+        # Mock the API response
+        mock_api = MagicMock()
+        mock_api_class.return_value = mock_api
+        mock_api.get.return_value = [
+            {"P1_001N": "689545", "state": "11", "NAME": "District of Columbia"}
+        ]
+
+        dc_variations = ["DC", "11", "District of Columbia"]
+
+        for dc_var in dc_variations:
+            try:
+                result = get_decennial(
+                    geography="state",
+                    variables=["P1_001N"],
+                    state=dc_var,
+                    year=2020,
+                    api_key="test_key",
+                )
+
+                assert isinstance(result, pd.DataFrame)
+
+                # Verify the API was called
+                mock_api.get.assert_called()
+                call_args = mock_api.get.call_args
+                geography_param = call_args[1]["geography"]
+                assert "11" in str(geography_param), f"Failed for {dc_var}: {geography_param}"
+
+            except Exception as e:
+                pytest.fail(f"get_decennial failed for DC variation '{dc_var}': {e}")
+
+    @patch("pytidycensus.acs.CensusAPI")
+    def test_mixed_states_including_dc(self, mock_api_class):
+        """Test multiple states including DC."""
+        mock_api = MagicMock()
+        mock_api_class.return_value = mock_api
+        mock_api.get.return_value = [
+            {"B01003_001E": "39538223", "state": "06", "NAME": "California"},
+            {"B01003_001E": "705749", "state": "11", "NAME": "District of Columbia"},
+            {"B01003_001E": "19453561", "state": "36", "NAME": "New York"},
+        ]
+
+        try:
+            result = get_acs(
+                geography="state",
+                variables=["B01003_001E"],
+                state=["CA", "DC", "New York"],  # Mixed formats with DC
+                year=2020,
+                api_key="test_key",
+            )
+
+            assert isinstance(result, pd.DataFrame)
+            mock_api.get.assert_called()
+
+        except Exception as e:
+            pytest.fail(f"Mixed states with DC failed: {e}")
+
+    def test_dc_edge_cases(self):
+        """Test DC edge cases in validation."""
+        from pytidycensus.utils import validate_state
+
+        # Test case insensitive
+        assert validate_state("dc") == ["11"]
+        assert validate_state("DC") == ["11"]
+        assert validate_state("Dc") == ["11"]
+
+        # Test with whitespace
+        assert validate_state(" DC ") == ["11"]
+        assert validate_state(" District of Columbia ") == ["11"]
+
+        # Test alternative formats
+        assert validate_state("D.C.") == ["11"]
+
+        # Test in lists with other states
+        result = validate_state(["CA", "DC", "NY"])
+        assert result == ["06", "11", "36"]
+
+
+if __name__ == "__main__":
+    # Run a simple test
+    test = TestDCIntegration()
+    test.test_dc_edge_cases()
+    print("✅ DC edge case tests passed!")

--- a/tests/test_state_validation.py
+++ b/tests/test_state_validation.py
@@ -1,0 +1,161 @@
+"""Tests for state validation functionality."""
+
+import pytest
+
+from pytidycensus.utils import validate_state
+
+
+class TestStateValidation:
+    """Test state validation with various inputs."""
+
+    def test_valid_state_abbreviations(self):
+        """Test valid state abbreviations."""
+        # Test standard states
+        assert validate_state("CA") == ["06"]
+        assert validate_state("NY") == ["36"]
+        assert validate_state("TX") == ["48"]
+        assert validate_state("FL") == ["12"]
+
+    def test_valid_state_names(self):
+        """Test valid state names."""
+        assert validate_state("California") == ["06"]
+        assert validate_state("New York") == ["36"]
+        assert validate_state("Texas") == ["48"]
+        assert validate_state("Florida") == ["12"]
+
+    def test_valid_fips_codes_string(self):
+        """Test valid FIPS codes as strings."""
+        assert validate_state("06") == ["06"]
+        assert validate_state("36") == ["36"]
+        assert validate_state("48") == ["48"]
+        assert validate_state("1") == ["01"]  # Should pad with zero
+
+    def test_valid_fips_codes_integer(self):
+        """Test valid FIPS codes as integers."""
+        assert validate_state(6) == ["06"]
+        assert validate_state(36) == ["36"]
+        assert validate_state(48) == ["48"]
+        assert validate_state(1) == ["01"]
+
+    def test_district_of_columbia_variations(self):
+        """Test District of Columbia in all valid formats."""
+        # These should all work for DC (FIPS 11)
+        assert validate_state("DC") == ["11"]
+        assert validate_state("11") == ["11"]
+        assert validate_state(11) == ["11"]
+        assert validate_state("District of Columbia") == ["11"]
+
+    def test_multiple_states(self):
+        """Test validation of multiple states at once."""
+        states = ["CA", "NY", "DC"]
+        expected = ["06", "36", "11"]
+        assert validate_state(states) == expected
+
+    def test_mixed_formats(self):
+        """Test mixed formats in a single call."""
+        states = ["CA", 36, "District of Columbia", "12"]
+        expected = ["06", "36", "11", "12"]
+        assert validate_state(states) == expected
+
+    def test_case_insensitive(self):
+        """Test that state validation is case insensitive."""
+        assert validate_state("ca") == ["06"]
+        assert validate_state("Ca") == ["06"]
+        assert validate_state("california") == ["06"]
+        assert validate_state("CALIFORNIA") == ["06"]
+        assert validate_state("dc") == ["11"]
+        assert validate_state("Dc") == ["11"]
+
+    def test_invalid_states(self):
+        """Test invalid state identifiers raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid state identifier"):
+            validate_state("ZZ")
+
+        with pytest.raises(ValueError, match="Invalid state identifier"):
+            validate_state("99")
+
+        with pytest.raises(ValueError, match="Invalid state identifier"):
+            validate_state("Invalid State")
+
+        with pytest.raises(ValueError, match="Invalid state identifier"):
+            validate_state(99)
+
+    def test_territories_and_outlying_areas(self):
+        """Test US territories and outlying areas."""
+        # Puerto Rico
+        assert validate_state("PR") == ["72"]
+        assert validate_state("Puerto Rico") == ["72"]
+        assert validate_state("72") == ["72"]
+
+        # Other territories if supported
+        territory_tests = [
+            ("AS", "60", "American Samoa"),
+            ("GU", "66", "Guam"),
+            ("MP", "69", "Northern Mariana Islands"),
+            ("VI", "78", "Virgin Islands"),
+        ]
+
+        for abbr, fips, name in territory_tests:
+            try:
+                assert validate_state(abbr) == [fips]
+                assert validate_state(name) == [fips]
+                assert validate_state(fips) == [fips]
+            except ValueError:
+                # Some territories might not be supported, that's OK
+                pass
+
+    def test_edge_cases(self):
+        """Test edge cases and boundary conditions."""
+        # Empty list should return empty list
+        assert validate_state([]) == []
+
+        # Single-item lists should work
+        assert validate_state(["CA"]) == ["06"]
+
+        # Leading/trailing whitespace should be handled
+        assert validate_state(" CA ") == ["06"]
+        assert validate_state(" District of Columbia ") == ["11"]
+
+    def test_fips_padding(self):
+        """Test that FIPS codes are properly zero-padded."""
+        # Single digit states should be zero-padded
+        assert validate_state(1) == ["01"]
+        assert validate_state("1") == ["01"]
+        assert validate_state(2) == ["02"]
+        assert validate_state("2") == ["02"]
+
+    def test_dc_is_special_case(self):
+        """Test that DC is handled as a special case since it's not in regular states list."""
+        # DC should work despite not being in us.STATES_AND_TERRITORIES
+        dc_variants = [
+            "DC",
+            "dc",
+            "Dc",
+            "11",
+            11,
+            "District of Columbia",
+            "district of columbia",
+            "DISTRICT OF COLUMBIA",
+        ]
+
+        for variant in dc_variants:
+            result = validate_state(variant)
+            assert result == ["11"], f"Failed for DC variant: {variant}"
+
+
+if __name__ == "__main__":
+    # Run some basic tests
+    test = TestStateValidation()
+    print("Testing DC variations...")
+    try:
+        test.test_district_of_columbia_variations()
+        print("✅ DC tests passed!")
+    except Exception as e:
+        print(f"❌ DC tests failed: {e}")
+
+    print("Testing regular states...")
+    try:
+        test.test_valid_state_abbreviations()
+        print("✅ Regular state tests passed!")
+    except Exception as e:
+        print(f"❌ Regular state tests failed: {e}")


### PR DESCRIPTION
This pull request improves the handling and validation of state parameters, with a particular focus on robust support for the District of Columbia (DC) across various formats. It enhances the `validate_state` utility to recognize DC in multiple representations, ensures zero-padding for FIPS codes, and adds comprehensive tests for both DC and other states and territories. These changes make the codebase more reliable and user-friendly for edge cases and mixed input formats.

**Enhancements to DC and state validation logic:**

* Improved `validate_state` in `pytidycensus/utils.py` to recognize DC in all common formats (e.g., "DC", "D.C.", "District of Columbia", "11", and case-insensitive variants), and to handle FIPS code zero-padding and direct attribute lookup for abbreviations, including DC as a special case.

**Expanded test coverage for DC and state validation:**

* Added `tests/test_dc_integration.py` with integration tests to verify that DC is accepted in all supported formats in main functions (`get_acs`, `get_decennial`), and that mixed state lists including DC are handled correctly. Also includes edge case tests for DC input variations.
* Added `tests/test_state_validation.py` with comprehensive unit tests for `validate_state`, covering standard states, DC, FIPS codes, territories, mixed formats, case insensitivity, whitespace handling, invalid inputs, and zero-padding behavior.