### PR TITLE
resolve missing data in int

### DIFF
--- a/docs/llm_assistant.md
+++ b/docs/llm_assistant.md
@@ -361,12 +361,6 @@ data = tc.get_acs(
     api_key=census_api_key
 )
 
-# Clean variable names by removing 'E' suffix
-column_mapping = {col: col[:-1] for col in data.columns
-                  if col.endswith('E') and '_' in col and col.split('_')[0].startswith('B')}
-if column_mapping:
-    data = data.rename(columns=column_mapping)
-
 print(f"Retrieved {data.shape[0]} rows and {data.shape[1]} columns")
 print(data.head())
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytidycensus"
-version = "1.0.0"
+version = "1.0.1"
 description = "Python interface to US Census Bureau APIs with LLM, pandas and GeoPandas support"
 readme = "README.md"
 license = {text = "MIT"}

--- a/pytidycensus/llm_interface/assistant.py
+++ b/pytidycensus/llm_interface/assistant.py
@@ -83,6 +83,7 @@ Extract any of the following information:
 - Location (state names, city names, etc.)
 - Time period (year, date range)
 - Data preferences (format, visualization needs)
+- SPATIAL/MAPPING needs (if user mentions: map, mapping, spatial, boundaries, visualization, plot, choropleth, GIS, explore, visualize, geographic patterns)
 
 Also classify the intent:
 - "initial": User starting new research
@@ -108,7 +109,8 @@ Respond with JSON matching this structure:
         "topic": "topic category",
         "geography": "census geography level",
         "state": "state code or name",
-        "year": 2020
+        "year": 2020,
+        "geometry": true_if_spatial_keywords_detected
     }},
     "suggested_next_steps": ["list", "of", "next", "steps"]
 }}
@@ -479,6 +481,21 @@ if column_mapping:
 
 print(f"Retrieved {{data.shape[0]}} rows and {{data.shape[1]}} columns")
 print(data.head())"""
+
+        # Add mapping code if geometry is enabled
+        if state.geometry:
+            code += f"""
+
+# Create interactive map (geometry=True gives you a GeoPandas GeoDataFrame)
+# No external shapefiles needed - pytidycensus handles it automatically!
+data.explore(
+    column='{state.variables[0][:-1] if state.variables and state.variables[0].endswith('E') else (state.variables[0] if state.variables else 'value')}',  # Use cleaned variable name
+    legend=True,
+    cmap='OrRd',  # Color scheme
+    tooltip=True
+)
+# Alternative: Static plot with matplotlib
+# data.plot(column='{state.variables[0][:-1] if state.variables and state.variables[0].endswith('E') else (state.variables[0] if state.variables else 'value')}', legend=True)"""
 
         return code
 

--- a/pytidycensus/llm_interface/conversation.py
+++ b/pytidycensus/llm_interface/conversation.py
@@ -263,13 +263,16 @@ Current conversation state:
    - For education: include total population 25+ (B15003_001E)
    - For employment: include total labor force (B23025_002E) or working age population (B23025_001E)
    - For housing: include total housing units (B25001_001E) or occupied units (B25002_002E)
-3. Ask clarifying questions to understand research needs
-4. Suggest specific variable codes with their normalization variables
-5. Show calculation examples for rates/percentages (e.g., poverty_rate = below_poverty / total_for_poverty)
-6. Explain geographic level tradeoffs (detail vs. sample size)
-7. Recommend ACS 5-year for small geographies, 1-year for timeliness
-8. Generate complete pytidycensus code with proper imports and calculations
-9. In most cases, recommend `geometry=True` for spatial analysis and plot using `data.explore()`
+3. **CRITICAL: ALWAYS set geometry=True for spatial/mapping requests** - this automatically includes shapefiles
+   - Keywords that REQUIRE geometry=True: map, mapping, spatial, geographic boundaries, visualization, plot, choropleth, GIS, spatial analysis, geographic patterns, explore, visualize
+   - pytidycensus automatically handles shapefile merging - no external spatial data needed
+   - Always use `data.explore()` or `data.plot()` for mapping GeoPandas DataFrames
+4. Ask clarifying questions to understand research needs
+5. Suggest specific variable codes with their normalization variables
+6. Show calculation examples for rates/percentages (e.g., poverty_rate = below_poverty / total_for_poverty)
+7. Explain geographic level tradeoffs (detail vs. sample size)
+8. Recommend ACS 5-year for small geographies, 1-year for timeliness
+9. Generate complete pytidycensus code with proper imports and calculations
 10. Explain what the data represents and any limitations
 
 ## Code Examples With Proper Normalization
@@ -317,7 +320,29 @@ data = tc.get_acs(
     api_key="your_key"
 )
 # Calculate rate: data['poverty_rate'] = data['B17001_002E'] / data['B17001_001E']
+
+# SPATIAL ANALYSIS - ALWAYS use geometry=True for mapping
+data = tc.get_acs(
+    geography="county",
+    variables=[
+        "B19013_001E",  # Median income
+        "B17001_002E",  # Below poverty
+        "B17001_001E",  # Total for poverty (denominator)
+    ],
+    state="TX",
+    year=2022,
+    output="wide",
+    geometry=True,  # CRITICAL: This includes shapefiles automatically
+    api_key="your_key"
+)
+# Calculate poverty rate
+data['poverty_rate'] = data['B17001_002E'] / data['B17001_001E']
+# Create map - no external shapefiles needed!
+data.explore(column='poverty_rate', legend=True, cmap='OrRd')
 ```
+
+**SPATIAL KEYWORDS**: If user mentions ANY of these words, ALWAYS set geometry=True:
+- map, mapping, spatial, boundaries, visualization, plot, choropleth, GIS, explore, visualize, geographic patterns, spatial analysis
 
 Remember: Census data has margins of error for ACS estimates. Help users understand their data quality."""
 

--- a/pytidycensus/llm_interface/conversation.py
+++ b/pytidycensus/llm_interface/conversation.py
@@ -226,7 +226,7 @@ You help users with these pytidycensus functions:
 
 ### Key pytidycensus Features
 - Returns pandas DataFrames by default
-- Use `geometry=True` to get GeoPandas GeoDataFrames with boundaries
+- Use `geometry=True` to get GeoPandas GeoDataFrames with boundaries for mapping and spatial analysis
 - Use `output="wide"` to spread variables across columns
 - Use dictionary for `variables` parameter to rename: {{"income": "B19013_001E"}}
 - Use `show_call=True` for debugging API calls
@@ -257,7 +257,7 @@ Current conversation state:
 
 ## Guidelines
 1. **ALWAYS use pytidycensus functions** - never suggest other libraries
-2. **CRITICAL: Always include normalization variables** - never suggest count variables without their totals
+2. **CRITICAL: Always include normalization variables if relevant** - never suggest count variables without their totals
    - For household data: include total households (B19001_001E, B11001_001E)
    - For population subgroups: include total population (B01003_001E, B02001_001E)
    - For education: include total population 25+ (B15003_001E)
@@ -269,7 +269,8 @@ Current conversation state:
 6. Explain geographic level tradeoffs (detail vs. sample size)
 7. Recommend ACS 5-year for small geographies, 1-year for timeliness
 8. Generate complete pytidycensus code with proper imports and calculations
-9. Explain what the data represents and any limitations
+9. In most cases, recommend `geometry=True` for spatial analysis and plot using `data.explore()`
+10. Explain what the data represents and any limitations
 
 ## Code Examples With Proper Normalization
 ```python
@@ -283,6 +284,7 @@ data = tc.get_acs(
         "B19001_001E",  # Total households (denominator)
     ],
     year=2022,
+    output="wide",
     api_key="your_key"
 )
 # Calculate rate: data['low_income_rate'] = data['B19001_002E'] / data['B19001_001E']
@@ -296,6 +298,7 @@ data = tc.get_acs(
     ],
     state="CA",
     year=2022,
+    output="wide",
     api_key="your_key"
 )
 # Calculate rate: data['college_rate'] = data['B15003_022E'] / data['B15003_001E']
@@ -310,6 +313,7 @@ data = tc.get_acs(
     state="NY",
     county="New York",
     year=2022,
+    output="wide",
     api_key="your_key"
 )
 # Calculate rate: data['poverty_rate'] = data['B17001_002E'] / data['B17001_001E']

--- a/pytidycensus/llm_interface/knowledge_base.py
+++ b/pytidycensus/llm_interface/knowledge_base.py
@@ -135,8 +135,12 @@ data = tc.get_acs(
     ],
     state="CA",
     year=2022,
+    output='wide',
     api_key="your_key"
 )
+# Calculate percentage with Bachelor's degree
+data['bachelor_rate'] = (data['B15003_022E'] / data['B01003_001E']) * 100
+
 """,
     "housing_analysis": """
 # Housing affordability analysis
@@ -152,9 +156,16 @@ data = tc.get_acs(
         "B25003_003E",  # Renter occupied
     ],
     state="CA",
-    year=2022,
+    year=2022,        
+    output='wide',
     api_key="your_key"
 )
+
+# Calculate rent as % of income
+data['rent_as_pct_income'] = (data['B25064_001E'] / data['B19013_001E']) * 100
+
+# Calculate home value as % of income
+data['home_value_as_pct_income'] = (data['B25077_001E'] / data['B19013_001E']) * 100
 """,
     "poverty_analysis": """
 # Poverty rate analysis
@@ -163,12 +174,13 @@ import pytidycensus as tc
 data = tc.get_acs(
     geography="county",
     variables=[
-        "B17001_002E",  # Below poverty line
+        "B17001_002E",  # Count below poverty line
         "B17001_001E",  # Total for poverty status
         "B01003_001E",  # Total population
     ],
     state="TX",
     year=2022,
+    output='wide',
     api_key="your_key"
 )
 
@@ -186,11 +198,12 @@ data = tc.get_acs(
     county="Los Angeles",
     geometry=True,  # Include geographic boundaries
     year=2022,
+    output='wide',
     api_key="your_key"
 )
 
 # This returns a GeoPandas GeoDataFrame ready for mapping
-data.plot(column='B19013_001E', legend=True)
+data.explore(column='B19013_001E', legend=True)
 """,
     "dc_analysis": """
 # Washington DC inequality analysis
@@ -208,12 +221,16 @@ data = tc.get_acs(
     ],
     state="DC",  # Works with "DC", "11", or "District of Columbia"
     year=2022,
+    geometry=True,  # Include geographic boundaries
     api_key="your_key"
 )
 
 # Calculate rates for proper analysis
 data['poverty_rate'] = data['B17001_002E'] / data['B17001_001E']
 data['low_income_rate'] = data['B19001_002E'] / data['B19001_001E']
+
+data.explore(column="poverty_rate", legend=True, cmap="OrRd")
+
 """,
 }
 

--- a/pytidycensus/utils.py
+++ b/pytidycensus/utils.py
@@ -830,7 +830,7 @@ def process_census_data(
     # Convert numeric columns
     for var in variables:
         if var in df.columns:
-            df[var] = pd.to_numeric(df[var], errors="coerce")
+            df[var] = pd.to_numeric(df[var], errors="coerce").astype("Int64")
 
     # Create GEOID from geography columns
     geo_cols = [

--- a/pytidycensus/utils.py
+++ b/pytidycensus/utils.py
@@ -830,7 +830,9 @@ def process_census_data(
     # Convert numeric columns
     for var in variables:
         if var in df.columns:
-            df[var] = pd.to_numeric(df[var], errors="coerce").astype("Int64")
+            df[var] = pd.to_numeric(df[var], errors="coerce")
+            if df[var].dtype == "Int8" or df[var].dtype == "Int32" or df[var].dtype == "Int16":
+                df[var] = df[var].astype("Int64")
 
     # Create GEOID from geography columns
     geo_cols = [

--- a/tests/test_acs.py
+++ b/tests/test_acs.py
@@ -568,9 +568,12 @@ class TestGetACS:
         assert result["estimate"].dtype in [
             "int64",
             "float64",
-            "object",
+            # "object",
         ]  # Can be string from API
-        assert result["moe"].dtype in ["int64", "float64", "object"]
+        assert result["moe"].dtype in [
+            "int64",
+            "float64",
+        ]  # "object"]
 
         # Verify GEOID format (state + county + tract)
         geoids = result["GEOID"].unique()


### PR DESCRIPTION
This pull request makes a small update to the way numeric census data is processed. Specifically, it ensures that numeric columns are converted to the pandas nullable integer type, which improves handling of missing values.

* Census data processing: Numeric columns in the DataFrame are now converted to the pandas `Int64` nullable integer type, instead of the default integer type, to better handle missing or invalid values. (`pytidycensus/utils.py`, [pytidycensus/utils.pyL833-R833](diffhunk://#diff-9bb74703226c925c6d004e2c41f6465de17005caa79481e44d7a980d329b285cL833-R833))